### PR TITLE
Add a function call to create the BINARY_DIR if it does not exist

### DIFF
--- a/include/AddSpirvModules.cmake
+++ b/include/AddSpirvModules.cmake
@@ -26,11 +26,11 @@ function(add_spirv_modules TARGET_NAME)
 	elseif(NOT IS_ABSOLUTE ${ARG_BINARY_DIR})
 		set(ARG_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${ARG_BINARY_DIR})
 		endif()
-		
- 	# Create the output directory if it doesn't exist
-        file(MAKE_DIRECTORY ${ARG_BINARY_DIR})
 
-        # Define custom compilation commands
+	# Create the output directory if it doesn't exist
+	file(MAKE_DIRECTORY ${ARG_BINARY_DIR})
+
+	# Define custom compilation commands
 	foreach(FILE IN LISTS ARG_SOURCES)
 		set(SOURCE_FILE ${ARG_SOURCE_DIR}/${FILE})
 		set(BINARY_FILE ${ARG_BINARY_DIR}/${FILE}.spv)

--- a/include/AddSpirvModules.cmake
+++ b/include/AddSpirvModules.cmake
@@ -26,8 +26,11 @@ function(add_spirv_modules TARGET_NAME)
 	elseif(NOT IS_ABSOLUTE ${ARG_BINARY_DIR})
 		set(ARG_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${ARG_BINARY_DIR})
 		endif()
+		
+ 	# Create the output directory if it doesn't exist
+        file(MAKE_DIRECTORY ${ARG_BINARY_DIR})
 
-	# Define custom compilation commands
+        # Define custom compilation commands
 	foreach(FILE IN LISTS ARG_SOURCES)
 		set(SOURCE_FILE ${ARG_SOURCE_DIR}/${FILE})
 		set(BINARY_FILE ${ARG_BINARY_DIR}/${FILE}.spv)


### PR DESCRIPTION
Add a function call to create the BINARY_DIR if it does not exist. This fixes that sometimes on multithreaded builds where the  project is built out of source that the BINARY_DIR may not yet exist at that point in the build process and thus glslc cannot be invoked. This creates the folder if it does not exist so it can be built correctly.